### PR TITLE
simplify big progress bar

### DIFF
--- a/src/parts/Form/Status/Progress/index.jsx
+++ b/src/parts/Form/Status/Progress/index.jsx
@@ -24,7 +24,7 @@ const ProgressBar = ({ ranges, max, window, syncedPercentage, isBig }) => {
                     <p key={i}>{range.start}-{range.end}</p>
                 ))}
             </Tooltip>
-            <Bar $ranges={ranges} $min={max - window} $window={window} $isBig={isBig}>
+            <Bar $ranges={ranges} $min={max - window} $window={window} $isBig={isBig} $syncedPercentage={syncedPercentage}>
                 {[...Array(ranges.length)].map((e, i) => <span key={i}></span>)}
             </Bar>
             <Num $isBig={isBig}>

--- a/src/parts/Form/Status/Progress/styles.js
+++ b/src/parts/Form/Status/Progress/styles.js
@@ -36,7 +36,18 @@ export const Bar = styled.div(props => css`
         border-radius: 6rem;
     `}
 
-    ${props.$ranges.map((range, index) => css`
+    ${props.$isBig ? css`
+        span:first-of-type {
+            position: absolute;
+            z-index: 1;
+            top: 0;
+            left: 0% !important;
+            height: 100%;
+            width: ${props.$syncedPercentage}% !important;
+            border-radius: 6rem;
+            background: linear-gradient(180deg, #CDB4DB 0%, #A2D2FF 100%);
+            transition: width .3s ease; 
+        }` : props.$ranges.map((range, index) => css`
         span:nth-of-type(${index + 1}) {
             position: absolute;
             z-index: 1;


### PR DESCRIPTION
Simplified big progress bar now:
![image](https://github.com/eigerco/lumina-front/assets/9157240/9d11e72a-6649-4181-9a22-8e380add438b)

small one, still showing position of synced ranges:

![image](https://github.com/eigerco/lumina-front/assets/9157240/25220393-da45-4133-8bcf-9a51772d03d1)
